### PR TITLE
Add `#match?` predicate support

### DIFF
--- a/spec/predicate_spec.cr
+++ b/spec/predicate_spec.cr
@@ -1,0 +1,40 @@
+require "./spec_helper"
+
+describe TreeSitter::Predicate do
+  it "supports `#match?`" do
+    parser = TreeSitter::Parser.new("json")
+    source = <<-JSON
+      {
+        "hello": 2
+        "goodnight": [
+          "moon", "sky", "earth", 1
+        ]
+      }
+      JSON
+
+    tree = parser.parse nil, source
+
+    query = TreeSitter::Query.new(parser.language, <<-SCM)
+      ((number) @test
+        (#match? @test "1"))
+      SCM
+
+    cursor = TreeSitter::QueryCursor.new(query)
+    cursor.exec(tree.root_node)
+
+    idx = 0
+    cursor.each_capture do |capture|
+      if idx == 0
+        capture.text(source).should eq("2")
+        TreeSitter::Predicate.resolve(query, capture, source).should eq(false)
+      elsif idx == 1
+        capture.text(source).should eq("1")
+        TreeSitter::Predicate.resolve(query, capture, source).should eq(true)
+      else
+        raise "shouldn't be here"
+      end
+    ensure
+      idx += 1
+    end
+  end
+end

--- a/src/tree_sitter.cr
+++ b/src/tree_sitter.cr
@@ -6,6 +6,7 @@ require "./tree_sitter/query"
 require "./tree_sitter/query_cursor"
 require "./tree_sitter/editor"
 require "./tree_sitter/range"
+require "./tree_sitter/predicate"
 
 private def calloc(n : LibC::SizeT, size : LibC::SizeT) : Pointer(Void)
   GC.malloc(n * size)

--- a/src/tree_sitter/capture.cr
+++ b/src/tree_sitter/capture.cr
@@ -1,5 +1,5 @@
 module TreeSitter
-  record Capture, rule : String, node : Node do
+  record Capture, rule : String, node : Node, capture_index : UInt32 do
     def includes_line?(line_n : Int32) : Bool
       node.start_point.row == line_n || node.end_point.row == line_n
     end

--- a/src/tree_sitter/predicate.cr
+++ b/src/tree_sitter/predicate.cr
@@ -1,0 +1,52 @@
+module TreeSitter
+  PREDICATES = {
+    "match?" => MatchPredicate,
+  }
+
+  abstract class Predicate
+    @query : TreeSitter::Query
+    @steps : Array(LibTreeSitter::TSQueryPredicateStep)
+
+    def initialize(@query, @steps)
+    end
+
+    def self.resolve(
+      query : TreeSitter::Query,
+      capture : TreeSitter::Capture,
+      source : String,
+    ) : Bool
+      unsafe_steps = LibTreeSitter.ts_query_predicates_for_pattern(
+        query,
+        capture.capture_index,
+        out step_count
+      )
+      steps = Slice.new(unsafe_steps, step_count).to_a
+
+      name_ptr = LibTreeSitter.ts_query_string_value_for_id(
+        query.to_unsafe, steps[0].value_id, out name_len
+      )
+
+      name = String.new(name_ptr, name_len)
+
+      !!PREDICATES[name]?.try(&.new(query, steps).call(capture, source))
+    end
+  end
+
+  class MatchPredicate < Predicate
+    def call(capture : TreeSitter::Capture, source : String) : Bool
+      # Get the regex pattern from the third step (steps[2])
+      pattern_ptr = LibTreeSitter.ts_query_string_value_for_id(
+        @query.to_unsafe,
+        @steps[2].value_id,
+        out pattern_len
+      )
+      pattern = String.new(pattern_ptr, pattern_len)
+
+      # Get the text from the captured node
+      node_text = capture.text(source)
+
+      # Match the captured text against the regex pattern
+      Regex.new(pattern).matches?(node_text)
+    end
+  end
+end

--- a/src/tree_sitter/query_cursor.cr
+++ b/src/tree_sitter/query_cursor.cr
@@ -63,7 +63,7 @@ module TreeSitter
       capture = match.captures[capture_index]
       ptr = LibTreeSitter.ts_query_capture_name_for_id(@query, capture.index, out strlen)
       rule = TreeSitter.string_pool.get(ptr, strlen)
-      Capture.new(rule, Node.new(capture.node))
+      Capture.new(rule, Node.new(capture.node), capture_index)
     end
 
     def each_capture(& : Capture -> Nil)


### PR DESCRIPTION
Predicates need to be implemented manually by the bindings as part of using the query cursor. This is one (basic) implementation that works, but it would be ideal if there was a better approach we could take that would be more general and cleaner. Open to suggestions and feedback.